### PR TITLE
Add missing docstrings

### DIFF
--- a/tbdynamics/camau/calibration/utils.py
+++ b/tbdynamics/camau/calibration/utils.py
@@ -452,6 +452,23 @@ def calculate_scenario_diff_cum_quantiles(
 
 
 def run_model_for_covid(params, output_dir, covid_configs, quantiles):
+    """Run the TB model for each COVID-19 configuration.
+
+    This helper loads previously extracted inference data and evaluates the
+    model under a series of COVID effect assumptions. Selected indicator
+    quantiles and the raw log-likelihood outputs are returned for each
+    scenario.
+
+    Args:
+        params (dict): Dictionary of model parameters.
+        output_dir (str | Path): Directory where extracted inference data are stored.
+        covid_configs (dict): Mapping of scenario names to COVID effect flags.
+        quantiles (Iterable[float]): Quantiles to calculate for the outputs.
+
+    Returns:
+        dict: Mapping of scenario name to a dictionary containing indicator
+        quantiles and log-likelihood results.
+    """
     covid_outputs = {}
 
     # Load the extracted InferenceData
@@ -503,6 +520,16 @@ def run_model_for_covid(params, output_dir, covid_configs, quantiles):
 
 
 def convert_ll_to_idata(ll_res):
+    """Convert raw log-likelihood outputs to an ``InferenceData`` object.
+
+    Args:
+        ll_res (dict): Dictionary containing log posterior, prior and
+            log-likelihood values for each sample.
+
+    Returns:
+        az.InferenceData: InferenceData instance populated with the supplied
+        log values.
+    """
     # Convert log-likelihoods into a DataFrame
     df = pd.DataFrame(ll_res)
 
@@ -520,6 +547,17 @@ def convert_ll_to_idata(ll_res):
 
 
 def calculate_waic_comparison(covid_outputs):
+    """Calculate and compare WAIC scores across scenarios.
+
+    Args:
+        covid_outputs (dict): Scenario mapping produced by
+            :func:`run_model_for_covid`, containing ``ll_res`` entries with
+            log-likelihood traces.
+
+    Returns:
+        pandas.DataFrame: Result of ``arviz.compare`` using WAIC as the
+        information criterion.
+    """
     waic_dict = {}
 
     for covid_name, output in covid_outputs.items():

--- a/tbdynamics/tools/detect.py
+++ b/tbdynamics/tools/detect.py
@@ -122,6 +122,21 @@ def adjust_detection_for_act3(
 
 
 def get_interpolation_rates_from_annual(rates: Dict[float, float]):
+    """Convert annual rates into a time-keyed dictionary for interpolation.
+
+    For a mapping of year to rate this helper inserts an additional key
+    halfway to the next year (``year + 0.1``) with the following year's
+    rate.  The resulting dictionary can then be fed into Summer's
+    interpolation utilities to produce a smooth time series.
+
+    Args:
+        rates (Dict[float, float]): Mapping of year to the rate observed in
+            that year.
+
+    Returns:
+        Dict[float, float]: Dictionary sorted by time containing both the
+            original annual rates and the inserted mid-year values.
+    """
     if not rates:
         return {}
     # Ensure keys are sorted floats

--- a/tbdynamics/tools/inputs.py
+++ b/tbdynamics/tools/inputs.py
@@ -182,6 +182,21 @@ def get_population_entry_rate(model_start_period):
 
 
 def get_age_groups_in_range(age_groups, lower_limit, upper_limit):
+    """Filter age-group labels by their starting age.
+
+    The function expects age-group strings such as ``"0-4"`` or
+    ``"65-69"`` and returns those whose lower bound lies within the
+    inclusive range defined by ``lower_limit`` and ``upper_limit``.
+
+    Args:
+        age_groups (Iterable[str]): Collection of age group labels.
+        lower_limit (int): Minimum starting age to include.
+        upper_limit (int): Maximum starting age to include.
+
+    Returns:
+        list[str]: Age group labels with a starting age between the two
+            limits.  Groups with a trailing ``"+"`` are ignored.
+    """
     return [
         i
         for i in age_groups
@@ -206,6 +221,20 @@ def load_params(param_path):
 
 
 def load_targets(target_path):
+    """Load calibration targets from a YAML file.
+
+    The YAML structure may map keys to either single values or to
+    sequences of three values ``[target, lower_bound, upper_bound]``.
+    This helper converts each entry into one or more ``pandas.Series``
+    objects for easier downstream processing.
+
+    Args:
+        target_path (str | Path): File path to the YAML data.
+
+    Returns:
+        dict: Mapping of processed target names to ``pandas.Series``
+        containing the target values and, when supplied, their bounds.
+    """
     with open(target_path, "r") as file:
         data = yaml.safe_load(file)
     processed_targets = {}

--- a/tbdynamics/tools/utils.py
+++ b/tbdynamics/tools/utils.py
@@ -228,6 +228,16 @@ def get_target_from_name(
 
 
 def get_row_col_for_subplots(i_panel, n_cols):
+    """Compute subplot row and column indices for a given panel index.
+
+    Args:
+        i_panel (int): Zero-based index of the subplot panel.
+        n_cols (int): Total number of columns in the subplot grid.
+
+    Returns:
+        tuple[int, int]: One-based row and column indices corresponding to the
+            panel's position in the grid.
+    """
     return int(np.floor(i_panel / n_cols)) + 1, i_panel % n_cols + 1
 
 

--- a/tbdynamics/vietnam/calibration/utils.py
+++ b/tbdynamics/vietnam/calibration/utils.py
@@ -475,6 +475,22 @@ def calculate_scenario_diff_cum_quantiles(
 
 
 def run_model_for_covid(params, output_dir, covid_configs, quantiles):
+    """Run the Vietnam TB model for a set of COVID-19 scenarios.
+
+    The function retrieves pre-computed inference data for each scenario,
+    evaluates the model and stores selected output quantiles along with the
+    raw log-likelihood information.
+
+    Args:
+        params (dict): Dictionary of model parameters.
+        output_dir (str | Path): Directory containing extracted inference data.
+        covid_configs (dict): Mapping of scenario name to COVID effect flags.
+        quantiles (Iterable[float]): Quantiles to compute for the outputs.
+
+    Returns:
+        dict: For each scenario a dictionary with ``indicator_outputs`` and
+        ``ll_res`` entries.
+    """
     covid_outputs = {}
 
     # Load the extracted InferenceData
@@ -526,6 +542,15 @@ def run_model_for_covid(params, output_dir, covid_configs, quantiles):
 
 
 def convert_ll_to_idata(ll_res):
+    """Convert log-likelihood traces to an ``InferenceData`` object.
+
+    Args:
+        ll_res (dict): Dictionary containing ``logposterior``, ``logprior``
+            and ``loglikelihood`` values.
+
+    Returns:
+        az.InferenceData: Object encapsulating the provided log values.
+    """
     # Convert log-likelihoods into a DataFrame
     df = pd.DataFrame(ll_res)
 
@@ -543,6 +568,16 @@ def convert_ll_to_idata(ll_res):
 
 
 def calculate_waic_comparison(covid_outputs):
+    """Compute WAIC for each scenario and return a comparison table.
+
+    Args:
+        covid_outputs (dict): Outputs from :func:`run_model_for_covid` with
+            log-likelihood results.
+
+    Returns:
+        pandas.DataFrame: Comparison of scenarios based on the WAIC
+        information criterion.
+    """
     waic_dict = {}
 
     for covid_name, output in covid_outputs.items():


### PR DESCRIPTION
## Summary
- document subplot index helper in utils
- add interpolation, age filtering and target loading docstrings
- document scenario utilities for COVID-19 model runs in Camau and Vietnam modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d89674be083219275e35fc4e3d004